### PR TITLE
Move environmental config to single script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Clone or copy the source into your own project. There are sections marked with `
 * logging - TODO decorators?
 * metrics - TODO
 * debug - see `.vscode/launch.json`, this is where debug profiles are defined which currently includes profiles to debug the application, run individual mocha tests and run all mocha tests
+* configuration - TODO all application configuration is via environment variables which are defined in a single script `src/config.ts` which gives defaults and documentation if appropiate to help deploy and configure the app (see [here](https://github.com/ministryofjustice/apvs-external-web/blob/develop/config.js) for an example)


### PR DESCRIPTION
All application configuration will be via Environment Variables (e.g. `process.env.API_URL`), as this is easy to configure when deploying into docker containers or PAAS.

As applications grow in size there will be a lot of Environment Variables, so we need to keep them in a single script so the application is self documenting and easier for someone unfamiliar to understand, providing a single file to look at rather than searching the code. The config script should supply defaults and comments to explain the config if appropriate and necessary, so environmental differences are easy to identify.